### PR TITLE
up the limit

### DIFF
--- a/commands/lit.js
+++ b/commands/lit.js
@@ -37,7 +37,7 @@ module.exports = {
 		  const rows = await sheet.getRows();
 
 			// Do not try to access MAX_ROW_NUMBER, only access one less.title than it
-			const MAX_ROW_NUMBER = 65
+			const MAX_ROW_NUMBER = 75
 		  await sheet.loadCells(`A1:C${MAX_ROW_NUMBER}`); // loads a range of cells
 
 			if(keyword == "help"){


### PR DESCRIPTION
- get serverID/googleSheet pairing from DB
- init script for EC2
- final touches
- up max row limit to 75
